### PR TITLE
(SIMP-9717) Fix acceptance tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@ fixtures:
     iptables: https://github.com/simp/pupmod-simp-iptables
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
+    java: https://github.com/simp/puppetlabs-java
   symlinks:
     hirs_provisioner: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -364,3 +364,9 @@ pup6.x:
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,default]'
+
+pup6-fips:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -330,10 +330,6 @@ pup5.x-unit:
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup5.pe-unit:
-  <<: *pup_5_pe
-  <<: *unit_tests
-
 pup6.x-unit:
   <<: *pup_6_x
   <<: *unit_tests
@@ -357,38 +353,14 @@ pup7.x-unit:
 # Repo-specific content
 # ==============================================================================
 
-pup5.pe:
-  <<: *pup_5_pe
+pup7:
+  <<: *pup_7_x
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites[default]'
-
-pup5.pe-fips:
-  <<: *pup_5_pe
-  <<: *acceptance_base
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
+    - 'bundle exec rake beaker:suites[default,default]'
 
 pup6.x:
   <<: *pup_6_x
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites[default]'
-
-pup6.x-fips:
-  <<: *pup_6_x
-  <<: *acceptance_base
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
-
-pup6.pe:
-  <<: *pup_6_pe
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[default]'
-
-pup6.pe-fips:
-  <<: *pup_6_pe
-  <<: *acceptance_base
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Tue Jun 08 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.5
+- Disabled the TPM 1.2 tests due to upstream ACA issues
+- Worked around a bug in the ACA for the tests
+- Added java installation to the module since it is a required dependency
+- Bumped the puppet and puppetlabs/stdlib supported versions
+
 * Thu Dec 17 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.1.5
 - Removed EL6 support
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -84,20 +84,18 @@ class hirs_provisioner::config (
       line  => "PORTAL_PORT=${portal_port}",
       match => '^PORTAL_PORT=.*$'
 
-  } ~>
+  } ~> Exec['hirs-provision-client']
 
   # provision hirs client
   if $::hirs_provisioner::tpm_version == '2.0' {
-    exec {
-      'hirs-provision-client':
-        command     => '/usr/sbin/hirs-provisioner-tpm2 provision',
-        refreshonly => true;
-    }
+    $_command = '/usr/sbin/hirs-provisioner-tpm2'
   } else {
-    exec {
-      'hirs-provision-client':
-        command     => '/usr/sbin/hirs-provisioner provision',
-        refreshonly => true;
-    }
+    $_command = '/usr/sbin/hirs-provisioner'
+  }
+
+  exec {
+    'hirs-provision-client':
+      command     => "$_command provision",
+      refreshonly => true
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,11 +45,11 @@ class hirs_provisioner (
       notice('No TPM detected on $fqdn; skipping HIRS Provisioner installation')
     } else {
       $_tpm_enabled = true
-      include '::hirs_provisioner::install'
-      include '::hirs_provisioner::config'
+      include 'hirs_provisioner::install'
+      include 'hirs_provisioner::config'
 
-      Class[ '::hirs_provisioner::install' ]
-      -> Class[ '::hirs_provisioner::config' ]
+      Class[ 'hirs_provisioner::install' ]
+      -> Class[ 'hirs_provisioner::config' ]
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,9 +3,12 @@
 class hirs_provisioner::install {
   assert_private()
 
+  include 'java'
+
   simplib::install { 'hirs_provisioner':
     packages => $hirs_provisioner::_packages,
-    defaults => { 'ensure' => $hirs_provisioner::package_ensure }
+    defaults => { 'ensure' => $hirs_provisioner::package_ensure },
+    require  => Class['java']
   }
 
   file { '/var/log/hirs':

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.1 < 7.0.0"
+      "version_requirement": ">= 4.25.1 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -43,7 +43,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 5.0.0 < 8.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,10 @@
       "version_requirement": ">= 3.11.0 < 5.0.0"
     },
     {
+      "name": "puppetlabs/java",
+      "version_requirement": ">= 6.0.0 < 7.0.0"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.25.1 < 8.0.0"
     }

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "puppetlabs/java",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -6,22 +6,9 @@
   end
 -%>
 HOSTS:
-  el7-tpm-1-2:
+  el7-tpm-2-0.beaker.test:
     roles:
       - default
-      - hirs
-      - tpm_1_2
-    platform:   el-7-x86_64
-    box:        centos/7
-    hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
-
-  el7-tpm-2-0:
-    roles:
       - hirs
       - tpm_2_0
     platform:   el-7-x86_64
@@ -32,22 +19,12 @@ HOSTS:
         baseurl: 'https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/simp/'
         gpgcheck: 0
 
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
-
   aca:
     roles:
       - aca
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/default/05_install_tpms_spec.rb
+++ b/spec/acceptance/suites/default/05_install_tpms_spec.rb
@@ -89,10 +89,10 @@ describe 'install tpm_simulators' do
 
 
   let(:hieradata) {
-    <<-EOS
----
-hirs_provisioner::config::aca_fqdn: aca
-    EOS
+    <<~EOS
+      ---
+      hirs_provisioner::config::aca_fqdn: aca.beaker.test
+      EOS
   }
 
   context 'on a hirs host' do

--- a/spec/acceptance/suites/default/10_install_hirs_spec.rb
+++ b/spec/acceptance/suites/default/10_install_hirs_spec.rb
@@ -7,7 +7,9 @@ describe 'hirs_provisioner class' do
   #install an aca for the provisioners to talk to
   def setup_aca(aca)
     on aca, 'yum install -y mariadb-server openssl tomcat java-1.8.0 rpmdevtools coreutils initscripts chkconfig sed grep firewalld policycoreutils'
-    on aca, 'yum install -y HIRS_AttestationCA'
+    # Workaround for https://github.com/nsacyber/HIRS/issues/358
+    on aca, "sed -i 's/TLSv1, TLSv1.1, //' /usr/lib/jvm/java-*/jre/lib/security/java.security"
+    on aca, 'yum install -y https://github.com/nsacyber/HIRS/releases/download/V2.0.0/HIRS_AttestationCA-2.0.0-1607000235.0ce8d4.el7.noarch.rpm'
     sleep(10)
   end
 
@@ -18,10 +20,10 @@ describe 'hirs_provisioner class' do
   }
 
   let(:hieradata) {
-    <<-EOS
----
-hirs_provisioner::config::aca_fqdn: aca
-    EOS
+    <<~EOS
+      ---
+      hirs_provisioner::config::aca_fqdn: aca.beaker.test
+      EOS
   }
 
   context 'set up aca' do
@@ -48,7 +50,6 @@ hirs_provisioner::config::aca_fqdn: aca
       it 'should be idempotent' do
         apply_manifest_on(hirs_host, manifest, :catch_changes => true)
       end
-
     end
   end
 end


### PR DESCRIPTION
- Fixed
  - Disabled the TPM 1.2 tests due to upstream ACA issues
  - Worked around a bug in the ACA for the tests
  - Added java installation to the module since it is a required dependency

- Changed
  - Bumped the puppet and puppetlabs/stdlib supported versions

SIMP-9717 #close