### PR TITLE
[puppetsync] Support simp-iptables 7.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 13 2024 Steven Pritchard <steve@sicura.us> - 0.5.0
+- [puppetsync] Update module dependencies to support simp-iptables 7.x
+
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 0.4.0
 - [puppetsync] Updates for Puppet 8
   - These updates may include the following:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-hirs_provisioner",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "SIMP Team",
   "summary": "Implement Host Integrity at Runtime and Startup Provisioner",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
     },
     {
       "name": "puppetlabs/java",
-      "version_requirement": ">= 6.0.0 < 11.0.0"
+      "version_requirement": ">= 6.0.0 < 12.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,6 @@ RSpec.configure do |c|
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 


### PR DESCRIPTION
Update module dependencies to support simp-iptables 7.x.